### PR TITLE
feat(cli): optimize buffer size for highest throughput

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Write};
 use std::process::exit;
 
-const BUFFER_SIZE: usize = 10 * 48 * 1024;
+const BUFFER_SIZE: usize = 100 * 48 * 1024;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]


### PR DESCRIPTION
From tests, ~5 KB buffer size provides about optimal CLI throughput. Additional buffer-size throughput gains require much larger buffer sizes for little improvement.